### PR TITLE
 Updating docs to reference NAS #3486

### DIFF
--- a/source/deployment/cluster.rst
+++ b/source/deployment/cluster.rst
@@ -296,7 +296,11 @@ Make sure you have set ``JobSettings.RunScheduler`` to ``true`` in config.json f
 Plugins and High Availability
 ^^^^^^^^^^^^^^^^
 
-As of Mattermost 5.14, when you install or upgrade a plugin, it is propagated across the servers in the cluster automatically. 
+As of Mattermost 5.14, when you install or upgrade a plugin, it is propagated across the servers in the cluster automatically.
+
+File storage is assumed to be shared between all the machines that are using services such as NAS or Amazon S3.
+
+If ``"DriverName": "local"`` is used then the directory at ``"FileSettings":`` ``"Directory": "./data/"`` is expected to be a NAS location mapped as a local directory, otherwise high availability will not function correctly and may corrupt your file storage.
 
 Note a slight behaviour change in 5.15:
 When you re-install a plugin in 5.14, the previous **Enabled** or **Disabled** state is retained. As of 5.15, a reinstalled plugin's initial state is **Disabled**.


### PR DESCRIPTION
This part of docs was updated to show the NAS suggestions under plugins and high availability, by using a bit of what was said under file storage configuration