### PR TITLE
Add (optional) pgpass steps to postgres installation in docs #3483

### DIFF
--- a/source/install/install-ubuntu-1604-postgresql.rst
+++ b/source/install/install-ubuntu-1604-postgresql.rst
@@ -100,5 +100,9 @@ Assume that the IP address of this server is 10.10.10.1
       You might have to install the PostgreSQL client software to use the command.
 
   The PostgreSQL interactive terminal starts. To exit the PostgreSQL interactive terminal, type ``\q`` and press **Enter**.
+  
+13. (Optional) Postgres recommends the standard way to pass passwords is through a ``.pgpass`` file. It is a special file that HAS to be 0600 in permissions otherwise it doesnt work. One can also pass the location of the file using the ``PGPASS`` env variable.
+
+  This leaves the security to the user running the application. If you run it as a service, then you need sudo permissions to   start a service file. Therefore, this file can be only root read-write and disabled for everybody else. After all, if you     are root, there's nothing you can't do
 
 With the database installed and the initial setup complete, you can now install the Mattermost server.


### PR DESCRIPTION
This part of docs was updated to add pgpass steps to Postgres installation in docs